### PR TITLE
Auth management authentication flows

### DIFF
--- a/README.md
+++ b/README.md
@@ -351,6 +351,7 @@ Demo code: https://github.com/keycloak/keycloak-nodejs-admin-client/blob/master/
 - Get authentication flows. Returns a list of authentication flows. (`GET /{realm}/authentication/flows`)
 - Get authentication flow for id (`GET /{realm}/authentication/flows/{id}`)
 - Update authentication flow (`PUT /{realm}/authentication/flows/{id}`)
+- Add new flow with new execution to existing flow (`POST /{realm}/authentication/flows/{flowAlias}/executions/flow`)
 - Delete authentication flow (`DELETE /{realm}/authentication/flows/{id}`)
 
 ### [Authentication Management: Authentication executions](https://www.keycloak.org/docs-api/9.0/rest-api/index.html#_authentication_management_resource)
@@ -361,6 +362,7 @@ Demo code: https://github.com/keycloak/keycloak-nodejs-admin-client/blob/master/
 - Get authentication executions for the flow. Returns a list of executions. (`GET /{realm}/authentication/flows/{flowAlias}/executions`)
 - Update authentication executions of a flow (`PUT /{realm}/authentication//flows/{flowAlias}/executions`)
 - Add a new authentication execution (`POST /{realm}/authentication/executions`)
+- Update execution with new configuration (`POST /{realm}/authentication/executions/{executionId}/config`)
 - Get single authentication execution (`GET /{realm}/authentication/executions/{executionId}`)
 - Lower authentication execution’s priority (`POST /{realm}/authentication/executions/{executionId}/lower-priority`)
 - Raise authentication execution’s priority (`POST /{realm}/authentication/executions/{executionId}/raise-priority`)

--- a/src/defs/authenticationExecutionExportRepresentation.ts
+++ b/src/defs/authenticationExecutionExportRepresentation.ts
@@ -10,5 +10,5 @@ export default interface AuthenticationExecutionExportRepresentation {
     flowAlias?: string;
     priority?: number;
     requirement?: string;
-    userSetupAllowed?: boolean
+    userSetupAllowed?: boolean;
 }

--- a/src/defs/authenticationFlowRepresentation.ts
+++ b/src/defs/authenticationFlowRepresentation.ts
@@ -1,7 +1,7 @@
 /**
  * https://www.keycloak.org/docs-api/10.0/rest-api/index.html#_authenticationflowrepresentation
  */
-import AuthenticationExecutionExportRepresentation from "./authenticationExecutionExportRepresentation";
+import AuthenticationExecutionExportRepresentation from './authenticationExecutionExportRepresentation';
 
 export default interface AuthenticationFlowRepresentation {
     alias?: string;
@@ -10,5 +10,5 @@ export default interface AuthenticationFlowRepresentation {
     description?: string;
     id?: string;
     providerId?: string;
-    topLevel?: boolean
+    topLevel?: boolean;
 }

--- a/src/defs/authenticatorConfigRepresentation.ts
+++ b/src/defs/authenticatorConfigRepresentation.ts
@@ -1,0 +1,9 @@
+/**
+ * https://www.keycloak.org/docs-api/10.0/rest-api/index.html#_authenticatorconfigrepresentation
+ */
+
+export default interface AuthenticatorConfigRepresentation {
+    alias?: string;
+    config?: Record<string, any>;
+    id?: string;
+}

--- a/src/resources/authenticationManagement.ts
+++ b/src/resources/authenticationManagement.ts
@@ -88,9 +88,12 @@ export class AuthenticationManagement extends Resource {
   });
 
   // Get authentication flow for id
-  public getAuthenticationFlowForId = this.makeRequest<{
-    id: string;
-  }, AuthenticationFlowRepresentation>({
+  public getAuthenticationFlowForId = this.makeRequest<
+    {
+      id: string;
+    },
+    AuthenticationFlowRepresentation
+  >({
     method: 'GET',
     path: '/flows/{id}',
     urlParamKeys: ['id'],
@@ -98,16 +101,18 @@ export class AuthenticationManagement extends Resource {
   });
 
   // Create a new authentication flow
-  public createAuthenticationFlow = this.makeRequest<AuthenticationFlowRepresentation>({
+  public createAuthenticationFlow = this.makeRequest<
+    AuthenticationFlowRepresentation
+  >({
     method: 'POST',
     path: '/flows',
   });
 
   // Add new flow with new execution to existing flow
   public addAuthenticationFlowToExistingFlow = this.makeUpdateRequest<
-      {flowAlias: string},
-      Record<string, any>
-      >({
+    {flowAlias: string},
+    Record<string, any>
+  >({
     method: 'POST',
     path: '/flows/{flowAlias}/executions/flow',
     urlParamKeys: ['flowAlias'],
@@ -115,9 +120,9 @@ export class AuthenticationManagement extends Resource {
 
   // Update an authentication flow
   public updateAuthenticationFlow = this.makeUpdateRequest<
-      {id: string},
-      AuthenticationFlowRepresentation
-      >({
+    {id: string},
+    AuthenticationFlowRepresentation
+  >({
     method: 'PUT',
     path: '/flows/{id}',
     urlParamKeys: ['id'],
@@ -142,9 +147,9 @@ export class AuthenticationManagement extends Resource {
   });
 
   public addAuthenticationExecutionToFlow = this.makeUpdateRequest<
-      {flowAlias: string},
-      AuthenticationExecution
-      >({
+    {flowAlias: string},
+    AuthenticationExecution
+  >({
     method: 'POST',
     path: '/flows/{flowAlias}/executions/execution',
     urlParamKeys: ['flowAlias'],
@@ -152,9 +157,9 @@ export class AuthenticationManagement extends Resource {
 
   // Update authentication executions of a flow
   public updateAuthenticationExecutions = this.makeUpdateRequest<
-      {flowAlias: string},
-      AuthenticationExecutionInfoRepresentation
-      >({
+    {flowAlias: string},
+    AuthenticationExecutionInfoRepresentation
+  >({
     method: 'PUT',
     path: '/flows/{flowAlias}/executions',
     urlParamKeys: ['flowAlias'],
@@ -162,14 +167,17 @@ export class AuthenticationManagement extends Resource {
 
   // Add new authentication execution
   public addAuthenticationExecution = this.makeRequest<
-      AuthenticationExecutionRepresentation
-      >({
+    AuthenticationExecutionRepresentation
+  >({
     method: 'POST',
     path: '/executions',
   });
 
   // Update execution with new configuration
-  public updateAuthenticationExecutionConfig = this.makeUpdateRequest<{executionId: string}, AuthenticatorConfigRepresentation>({
+  public updateAuthenticationExecutionConfig = this.makeUpdateRequest<
+    {executionId: string},
+    AuthenticatorConfigRepresentation
+  >({
     method: 'POST',
     path: '/executions/{executionId}/config',
     urlParamKeys: ['executionId'],

--- a/src/resources/authenticationManagement.ts
+++ b/src/resources/authenticationManagement.ts
@@ -5,6 +5,7 @@ import AuthenticationExecutionInfoRepresentation from '../defs/authenticationExe
 import AuthenticationFlowRepresentation from '../defs/authenticationFlowRepresentation';
 import AuthenticationExecution from '../defs/authenticationExecution';
 import AuthenticationExecutionRepresentation from '../defs/authenticationExecutionRepresentation';
+import AuthenticatorConfigRepresentation from '../defs/authenticatorConfigRepresentation';
 
 export class AuthenticationManagement extends Resource {
   /**
@@ -102,6 +103,16 @@ export class AuthenticationManagement extends Resource {
     path: '/flows',
   });
 
+  // Create a new flow with new execution to existing flow
+  public addAuthenticationFlowToExistingFlow = this.makeUpdateRequest<
+      {flowAlias: string},
+      Record<string, any>
+      >({
+    method: 'POST',
+    path: '/flows/{flowAlias}/executions/flow',
+    urlParamKeys: ['flowAlias'],
+  });
+
   // Update an authentication flow
   public updateAuthenticationFlow = this.makeUpdateRequest<
       {id: string},
@@ -130,7 +141,6 @@ export class AuthenticationManagement extends Resource {
     urlParamKeys: ['flowAlias'],
   });
 
-  // Add new authentication execution to a flow
   public addAuthenticationExecutionToFlow = this.makeUpdateRequest<
       {flowAlias: string},
       AuthenticationExecution
@@ -156,6 +166,13 @@ export class AuthenticationManagement extends Resource {
       >({
     method: 'POST',
     path: '/executions',
+  });
+
+  // Update execution with new configuration
+  public updateAuthenticationExecutionConfig = this.makeUpdateRequest<{executionId: string}, AuthenticatorConfigRepresentation>({
+    method: 'POST',
+    path: '/executions/{executionId}/config',
+    urlParamKeys: ['executionId'],
   });
 
   // Get single execution

--- a/src/resources/authenticationManagement.ts
+++ b/src/resources/authenticationManagement.ts
@@ -103,7 +103,7 @@ export class AuthenticationManagement extends Resource {
     path: '/flows',
   });
 
-  // Create a new flow with new execution to existing flow
+  // Add new flow with new execution to existing flow
   public addAuthenticationFlowToExistingFlow = this.makeUpdateRequest<
       {flowAlias: string},
       Record<string, any>

--- a/test/authenticationManagement.spec.ts
+++ b/test/authenticationManagement.spec.ts
@@ -13,7 +13,7 @@ declare module 'mocha' {
     kcAdminClient?: KeycloakAdminClient;
     currentRealm?: string;
     requiredActionProvider?: Record<string, any>;
-    authenticationFlowProvider?: AuthenticationFlowRepresentation [];
+    authenticationFlowProvider?: AuthenticationFlowRepresentation[];
     authenticationExecutionProvider?: Record<string, any>;
     authenticationFlowInsideFlowProvider?: Record<string, any>;
     authenticationExecutionInsideFlowProvider?: Record<string, any>;
@@ -38,11 +38,11 @@ describe('Authentication management', function() {
 
   after(async () => {
     // delete test realm
-    // await this.kcAdminClient.realms.del({realm: this.currentRealm});
-    // const realm = await this.kcAdminClient.realms.findOne({
-    //   realm: this.currentRealm,
-    // });
-    // expect(realm).to.be.null;
+    await this.kcAdminClient.realms.del({realm: this.currentRealm});
+    const realm = await this.kcAdminClient.realms.findOne({
+      realm: this.currentRealm,
+    });
+    expect(realm).to.be.null;
   });
 
   /**
@@ -136,247 +136,261 @@ describe('Authentication management', function() {
    * Authentication flows
    */
   describe('Authentication flows', () => {
-     it('should create new authentication flow', async () => {
-         try {
-             const flowAlias = faker.internet.userName();
-             const flowId = faker.internet.userName();
-             const authenticationFlow = await this.kcAdminClient.authenticationManagement.createAuthenticationFlow(
-                 {
-                     id: flowId,
-                     alias: flowAlias,
-                     builtIn: false,
-                     description: '',
-                     providerId: 'basic-flow',
-                     topLevel: true,
-                 },
-             );
-             expect(authenticationFlow).to.be.empty;
-             this.authenticationFlowProvider = new Array();
-             this.authenticationFlowProvider[0] = {id: flowId, alias: flowAlias};
-         } catch (e) {
-             console.log(e);
-         }
+    it('should create new authentication flow', async () => {
+      const flowAlias = faker.internet.userName();
+      const flowId = faker.internet.userName();
+      const authenticationFlow = await this.kcAdminClient.authenticationManagement.createAuthenticationFlow(
+        {
+          id: flowId,
+          alias: flowAlias,
+          builtIn: false,
+          description: '',
+          providerId: 'basic-flow',
+          topLevel: true,
+        },
+      );
+      expect(authenticationFlow).to.be.empty;
+      this.authenticationFlowProvider = new Array();
+      this.authenticationFlowProvider[0] = {id: flowId, alias: flowAlias};
+    });
 
-     });
+    it('should get authentication flows', async () => {
+      const authenticationFlows = await this.kcAdminClient.authenticationManagement.getAuthenticationFlows();
+      expect(authenticationFlows).to.be.an('array');
+    });
 
-     it('should get authentication flows', async () => {
-       const authenticationFlows = await this.kcAdminClient.authenticationManagement.getAuthenticationFlows();
-       expect(authenticationFlows).to.be.an('array');
-     });
+    it('should get authentication flow by id', async () => {
+      const authenticationFlow = await this.kcAdminClient.authenticationManagement.getAuthenticationFlowForId(
+        {id: this.authenticationFlowProvider[0].id},
+      );
+      expect(authenticationFlow).to.be.ok;
+    });
 
-     it('should get authentication flow by id', async () => {
-       const authenticationFlow = await this.kcAdminClient.authenticationManagement.getAuthenticationFlowForId(
-           {id: this.authenticationFlowProvider[0].id},
-       );
-       expect(authenticationFlow).to.be.ok;
-     });
+    it('should update authentication flow', async () => {
+      const authenticationFlow = await this.kcAdminClient.authenticationManagement.getAuthenticationFlowForId(
+        {id: this.authenticationFlowProvider[0].id},
+      );
+      const response = await this.kcAdminClient.authenticationManagement.updateAuthenticationFlow(
+        {id: this.authenticationFlowProvider[0].id},
+        {
+          ...authenticationFlow,
+          builtIn: false,
+          description: 'test',
+        },
+      );
+      expect(response.description).to.be.equal('test');
+    });
 
-     it('should update authentication flow', async () => {
-       const authenticationFlow = await this.kcAdminClient.authenticationManagement.getAuthenticationFlowForId(
-           {id: this.authenticationFlowProvider[0].id},
-       );
-       const response = await this.kcAdminClient.authenticationManagement.updateAuthenticationFlow(
-           {id: this.authenticationFlowProvider[0].id},
-           {
-             ...authenticationFlow,
-             builtIn: false,
-             description: 'test',
-           },
-       );
-       expect(response.description).to.be.equal('test');
-     });
+    it('should add execution to authentication flow', async () => {
+      const response = await this.kcAdminClient.authenticationManagement.addAuthenticationExecutionToFlow(
+        {flowAlias: this.authenticationFlowProvider[0].alias},
+        {provider: 'reset-password'},
+      );
+      await this.kcAdminClient.authenticationManagement.addAuthenticationExecutionToFlow(
+        {flowAlias: this.authenticationFlowProvider[0].alias},
+        {provider: 'reset-credentials-choose-user'},
+      );
+      expect(response).to.be.empty;
+    });
 
-     it('should add execution to authentication flow', async () => {
-       const response = await this.kcAdminClient.authenticationManagement.addAuthenticationExecutionToFlow(
-           {flowAlias: this.authenticationFlowProvider[0].alias},
-           {provider: 'reset-password'},
-       );
-       await this.kcAdminClient.authenticationManagement.addAuthenticationExecutionToFlow(
-           {flowAlias: this.authenticationFlowProvider[0].alias},
-           {provider: 'reset-credentials-choose-user'},
-       );
-       expect(response).to.be.empty;
-     });
+    it('should add execution', async () => {
+      const response = await this.kcAdminClient.authenticationManagement.addAuthenticationExecution(
+        {
+          authenticator: 'reset-password-additional-step',
+          autheticatorFlow: false,
+          priority: 30,
+          requirement: 'REQUIRED',
+          parentFlow: this.authenticationFlowProvider[0].id,
+        },
+      );
+      expect(response).to.be.empty;
+    });
 
-     it('should add execution', async () => {
-       const response = await this.kcAdminClient.authenticationManagement.addAuthenticationExecution(
-           {authenticator: 'reset-password-additional-step',  autheticatorFlow: false, priority: 30, requirement: 'REQUIRED', parentFlow: this.authenticationFlowProvider[0].id},
-       );
-       expect(response).to.be.empty;
-     });
+    it('should get single execution', async () => {
+      // tslint:disable-next-line:max-line-length
+      const executions = await this.kcAdminClient.authenticationManagement.getAuthenticationExecutions(
+        {flowAlias: this.authenticationFlowProvider[0].alias},
+      );
+      const execution = await this.kcAdminClient.authenticationManagement.getExecutionForId(
+        {executionId: executions[0].id},
+      );
+      expect(execution.authenticator).to.be.equal('reset-password');
+      this.authenticationExecutionProvider = execution;
+    });
 
-     it('should get single execution', async () => {
-       // tslint:disable-next-line:max-line-length
-       const executions = await this.kcAdminClient.authenticationManagement.getAuthenticationExecutions({flowAlias: this.authenticationFlowProvider[0].alias});
-       const execution = await this.kcAdminClient.authenticationManagement.getExecutionForId(
-           {executionId: executions[0].id},
-       );
-       expect(execution.authenticator).to.be.equal('reset-password');
-       this.authenticationExecutionProvider = execution;
-     });
+    it('should update execution of authentication flow', async () => {
+      const response = await this.kcAdminClient.authenticationManagement.updateAuthenticationExecutions(
+        {flowAlias: this.authenticationFlowProvider[0].alias},
+        {
+          configurable: true,
+          displayName: 'Reset Password',
+          flowId: this.authenticationFlowProvider[0].id,
+          id: this.authenticationExecutionProvider.id,
+          index: 0,
+          level: 0,
+          providerId: 'reset-password',
+          requirement: 'ALTERNATIVE',
+        },
+      );
+      expect(response).to.be.empty;
+    });
 
-     it('should update execution of authentication flow', async () => {
-       const response = await this.kcAdminClient.authenticationManagement.updateAuthenticationExecutions(
-           {flowAlias: this.authenticationFlowProvider[0].alias},
-           {
-             configurable: true,
-             displayName: 'Reset Password',
-             flowId: this.authenticationFlowProvider[0].id,
-             id: this.authenticationExecutionProvider.id,
-             index: 0,
-             level: 0,
-             providerId: 'reset-password',
-             requirement: 'ALTERNATIVE', },
-         );
-       expect(response).to.be.empty;
-     });
+    it('should update authentication execution configuration', async () => {
+      const response = await this.kcAdminClient.authenticationManagement.updateAuthenticationExecutionConfig(
+        {executionId: this.authenticationExecutionProvider.id},
+        {
+          alias: 'reset-password',
+          config: {
+            authenticator: 'reset-password',
+            requirement: 'REQUIRED',
+            priority: 2,
+            userSetupAllowed: false,
+            autheticatorFlow: false,
+          },
+          id: 'reset-password',
+        },
+      );
+      expect(response).to.be.empty;
+    });
 
-     it('should update authentication execution configuration', async () => {
-         // tslint:disable-next-line:max-line-length
-             const response = await this.kcAdminClient.authenticationManagement.updateAuthenticationExecutionConfig({executionId: this.authenticationExecutionProvider.id},
-                 {
-                     alias: 'reset-password',
-                     config: {
-                         authenticator: 'reset-password',
-                         requirement: 'REQUIRED',
-                         priority: 2,
-                         userSetupAllowed: false,
-                         autheticatorFlow: false,
-                     },
-                     id: 'reset-password',
-                 },
-             );
-         // tslint:disable-next-line:max-line-length
-             await this.kcAdminClient.authenticationManagement.updateAuthenticationExecutionConfig({executionId: this.authenticationExecutionProvider.id},
-                 {
-                     alias: 'reset-credentials-choose-user',
-                     config: {
-                         authenticator: 'reset-credentials-choose-user',
-                         requirement: 'REQUIRED',
-                         priority: 1,
-                         userSetupAllowed: false,
-                         autheticatorFlow: false,
-                     },
-                     id: 'reset-credentials-choose-user',
-                 },
-             );
-             // expect(response).to.be.empty;
+    it('should lower execution priority', async () => {
+      const execution = await this.kcAdminClient.authenticationManagement.getExecutionForId(
+        {executionId: this.authenticationExecutionProvider.id},
+      );
+      const response = await this.kcAdminClient.authenticationManagement.lowerExecutionPriority(
+        {executionId: this.authenticationExecutionProvider.id},
+      );
+      expect(response).to.be.empty;
+      const executionUpdated = await this.kcAdminClient.authenticationManagement.getExecutionForId(
+        {executionId: this.authenticationExecutionProvider.id},
+      );
+      expect(executionUpdated.priority).to.be.greaterThan(execution.priority);
+    });
+
+    it('should raise execution priority', async () => {
+      const execution = await this.kcAdminClient.authenticationManagement.getExecutionForId(
+        {executionId: this.authenticationExecutionProvider.id},
+      );
+      const response = await this.kcAdminClient.authenticationManagement.raiseExecutionPriority(
+        {executionId: this.authenticationExecutionProvider.id},
+      );
+      expect(response).to.be.empty;
+      const executionUpdated = await this.kcAdminClient.authenticationManagement.getExecutionForId(
+        {executionId: this.authenticationExecutionProvider.id},
+      );
+      expect(executionUpdated.priority).to.be.lessThan(execution.priority);
+    });
+
+    it('should delete execution', async () => {
+      await this.kcAdminClient.authenticationManagement.deleteExecution({
+        executionId: this.authenticationExecutionProvider.id,
       });
+      const execution = await this.kcAdminClient.authenticationManagement.getExecutionForId(
+        {
+          executionId: this.authenticationExecutionProvider.id,
+        },
+      );
+      expect(execution).to.be.null;
+    });
 
-     it('should lower execution priority', async () => {
-       const execution = await this.kcAdminClient.authenticationManagement.getExecutionForId(
-           {executionId: this.authenticationExecutionProvider.id},
-       );
-       const response = await this.kcAdminClient.authenticationManagement.lowerExecutionPriority(
-           {executionId: this.authenticationExecutionProvider.id},
-       );
-       expect(response).to.be.empty;
-       const executionUpdated = await this.kcAdminClient.authenticationManagement.getExecutionForId(
-           {executionId: this.authenticationExecutionProvider.id},
-       );
-       expect(executionUpdated.priority).to.be.greaterThan(
-           execution.priority,
-       );
-     });
+    it('should delete authentication flow by id', async () => {
+      await this.kcAdminClient.authenticationManagement.deleteAuthenticationFlow(
+        {
+          id: this.authenticationFlowProvider[0].id,
+        },
+      );
+      const authenticationFlow = await this.kcAdminClient.authenticationManagement.getAuthenticationFlowForId(
+        {
+          id: this.authenticationFlowProvider[0].id,
+        },
+      );
+      expect(authenticationFlow).to.be.null;
+    });
 
-     it('should raise execution priority', async () => {
-       const execution = await this.kcAdminClient.authenticationManagement.getExecutionForId(
-           {executionId: this.authenticationExecutionProvider.id},
-       );
-       const response = await this.kcAdminClient.authenticationManagement.raiseExecutionPriority(
-           {executionId: this.authenticationExecutionProvider.id},
-       );
-       expect(response).to.be.empty;
-       const executionUpdated = await this.kcAdminClient.authenticationManagement.getExecutionForId(
-           {executionId: this.authenticationExecutionProvider.id},
-       );
-       expect(executionUpdated.priority).to.be.lessThan(
-           execution.priority,
-       );
-     });
+    // Authentication flow with form flow inside
+    it('should create new authentication flow', async () => {
+      const flowAlias = faker.internet.userName();
+      const flowId = faker.internet.userName();
+      const authenticationFlow = await this.kcAdminClient.authenticationManagement.createAuthenticationFlow(
+        {
+          id: flowId,
+          alias: flowAlias,
+          builtIn: false,
+          description: '',
+          providerId: 'basic-flow',
+          topLevel: true,
+        },
+      );
+      expect(authenticationFlow).to.be.empty;
+      this.authenticationFlowProvider[1] = {id: flowId, alias: flowAlias};
+    });
 
-      it('should create new authentication flow', async () => {
-          const flowAlias = faker.internet.userName();
-          const flowId = faker.internet.userName();
-          const authenticationFlow = await this.kcAdminClient.authenticationManagement.createAuthenticationFlow(
-              {
-                  id: flowId,
-                  alias: flowAlias,
-                  builtIn: false,
-                  description: '',
-                  providerId: 'basic-flow',
-                  topLevel: true,
-              },
-          );
-          expect(authenticationFlow).to.be.empty;
-          this.authenticationFlowProvider[1] = {id: flowId, alias: flowAlias};
+    it('should add new flow with new execution to existing flow', async () => {
+      const flowAlias = faker.internet.userName();
+      const flowId = faker.internet.userName();
+      const response = await this.kcAdminClient.authenticationManagement.addAuthenticationFlowToExistingFlow(
+        {flowAlias: this.authenticationFlowProvider[1].alias},
+        {
+          id: flowId,
+          alias: flowAlias,
+          type: 'form-flow',
+          provider: 'test',
+          description: '',
+        },
+      );
+      expect(response).to.be.empty;
+      this.authenticationFlowInsideFlowProvider = {
+        alias: flowAlias,
+        id: flowId,
+      };
+    });
+
+    it('should add execution to new flow', async () => {
+      const response = await this.kcAdminClient.authenticationManagement.addAuthenticationExecutionToFlow(
+        {flowAlias: this.authenticationFlowInsideFlowProvider.alias},
+        {provider: 'registration-user-creation'},
+      );
+
+      const executions = await this.kcAdminClient.authenticationManagement.getAuthenticationExecutions(
+        {flowAlias: this.authenticationFlowInsideFlowProvider.alias},
+      );
+      this.authenticationExecutionInsideFlowProvider = executions[0];
+      expect(response).to.be.empty;
+    });
+
+    it('should delete new flow with executions', async () => {
+      const authenticationExecutions = await this.kcAdminClient.authenticationManagement.getAuthenticationExecutions(
+        {flowAlias: this.authenticationFlowProvider[1].alias},
+      );
+      const authenticationFlowInsideFlow = authenticationExecutions.find(
+        execution =>
+          execution.displayName ===
+          this.authenticationFlowInsideFlowProvider.alias,
+      );
+
+      await this.kcAdminClient.authenticationManagement.deleteExecution({
+        executionId: authenticationFlowInsideFlow.id,
       });
+      const authenticationFlow = await this.kcAdminClient.authenticationManagement.getExecutionForId(
+        {
+          executionId: authenticationFlowInsideFlow.id,
+        },
+      );
+      expect(authenticationFlow).to.be.null;
+    });
 
-     it('should add new flow with new execution to existing flow', async () => {
-          const flowAlias = faker.internet.userName();
-          const flowId = faker.internet.userName();
-          const response = await this.kcAdminClient.authenticationManagement.addAuthenticationFlowToExistingFlow(
-              {flowAlias: this.authenticationFlowProvider[1].alias},
-              {
-                  id: flowId,
-                  alias: flowAlias,
-                  type: 'form-flow',
-                  provider: 'test',
-                  description: ''},
-          );
-          expect(response).to.be.empty;
-          this.authenticationFlowInsideFlowProvider = {id: flowId, alias: flowAlias};
-      });
-
-     it('should add execution to new flow', async () => {
-         try {
-             const response = await this.kcAdminClient.authenticationManagement.addAuthenticationExecutionToFlow(
-                 {flowAlias: this.authenticationFlowInsideFlowProvider.alias},
-                 {provider: "registration-user-creation"}
-             );
-             const executions = await this.kcAdminClient.authenticationManagement.getAuthenticationExecutions({flowAlias: this.authenticationFlowInsideFlowProvider.alias});
-             this.authenticationExecutionInsideFlowProvider = executions[0];
-             expect(response).to.be.empty;
-         } catch (e) {
-             console.log("ERROR", e);
-         }
-
-      });
-
-      it('should update execution of authentication flow', async () => {
-          const response = await this.kcAdminClient.authenticationManagement.updateAuthenticationExecutions(
-              {flowAlias: this.authenticationFlowInsideFlowProvider.alias},
-              {
-                  configurable: true,
-                  flowId: this.authenticationFlowInsideFlowProvider.id,
-                  id: this.authenticationExecutionInsideFlowProvider .id,
-                  index: 0,
-                  level: 0,
-                  requirement: 'REQUIRED', },
-          );
-          expect(response).to.be.empty;
-      });
-
-
-
-     // it('should delete execution', async () => {
-     //   await this.kcAdminClient.authenticationManagement.deleteExecution({
-     //     executionId: this.authenticationExecutionProvider.id,
-     //   });
-     //   const execution = await this.kcAdminClient.authenticationManagement.getExecutionForId({
-     //     executionId: this.authenticationExecutionProvider.id,
-     //   });
-     //   expect(execution).to.be.null;
-     // });
-     //
-     // it('should delete authentication flow by id', async () => {
-     //   await this.kcAdminClient.authenticationManagement.deleteAuthenticationFlow({
-     //     id: this.authenticationFlowProvider.id,
-     //   });
-     //   const authenticationFlow = await this.kcAdminClient.authenticationManagement.getAuthenticationFlowForId({
-     //     id: this.authenticationFlowProvider.id,
-     //   });
-     //   expect(authenticationFlow).to.be.null;
-     // });
-   });
+    it('should delete authentication flow by id', async () => {
+      await this.kcAdminClient.authenticationManagement.deleteAuthenticationFlow(
+        {
+          id: this.authenticationFlowProvider[1].id,
+        },
+      );
+      const authenticationFlow = await this.kcAdminClient.authenticationManagement.getAuthenticationFlowForId(
+        {
+          id: this.authenticationFlowProvider[1].id,
+        },
+      );
+      expect(authenticationFlow).to.be.null;
+    });
+  });
 });

--- a/test/authenticationManagement.spec.ts
+++ b/test/authenticationManagement.spec.ts
@@ -207,7 +207,6 @@ describe('Authentication management', function() {
     });
 
     it('should get single execution', async () => {
-      // tslint:disable-next-line:max-line-length
       const executions = await this.kcAdminClient.authenticationManagement.getAuthenticationExecutions(
         {flowAlias: this.authenticationFlowProvider[0].alias},
       );


### PR DESCRIPTION
**Description**
Authentication management - added support for adding form and base flows with executions inside authentication flows

**Acceptance criteria**
- extend Keycloak client in order to have support for adding flows inside existing flows

(OPTIONAL)**How to test**
- run tests `yarn test`